### PR TITLE
Add database support

### DIFF
--- a/patches/0001-Special-case-the-groups-table-for-mysql-backend.patch
+++ b/patches/0001-Special-case-the-groups-table-for-mysql-backend.patch
@@ -1,0 +1,52 @@
+From a619ea438baf450dda9cf48c9cc478fd8ccb6b3d Mon Sep 17 00:00:00 2001
+From: Billy Olsen <billy.olsen@canonical.com>
+Date: Wed, 23 Aug 2023 15:00:36 -0700
+Subject: [PATCH] Special case the groups table for mysql backend.
+
+groups is a reserved keyword for mysql/mariadb. This checks the
+backend database driver and escapes the groups table name if the
+mysql driver is used.
+
+Signed-off-by: Billy Olsen <billy.olsen@canonical.com>
+
+diff --git a/v2/pkg/plugins/basesqlhandler.go b/v2/pkg/plugins/basesqlhandler.go
+index efff83c..b88b063 100644
+--- a/v2/pkg/plugins/basesqlhandler.go
++++ b/v2/pkg/plugins/basesqlhandler.go
+@@ -183,8 +183,13 @@ func (h databaseHandler) FindGroup(groupName string) (f bool, g config.Group, er
+ 	group := config.Group{}
+ 	found := false
+ 
++	var groups_table = "groups"
++	if h.sqlBackend.GetDriverName() == "mysql" {
++		groups_table = "`groups`"
++	}
++
+ 	err = h.database.cnx.QueryRow(fmt.Sprintf(`
+-			SELECT g.gidnumber FROM groups g WHERE lower(name)=%s`, h.sqlBackend.GetPrepareSymbol()), groupName).Scan(
++			SELECT g.gidnumber FROM %s g WHERE lower(name)=%s`, groups_table, h.sqlBackend.GetPrepareSymbol()), groupName).Scan(
+ 		&group.GIDNumber)
+ 	if err == nil {
+ 		found = true
+@@ -312,11 +317,15 @@ func (h databaseHandler) commaListToStringTable(commaList string) []string {
+ 
+ func (h databaseHandler) memoizeGroups() ([]config.Group, error) {
+ 	workMemGroups := make([]*config.Group, 0)
+-	rows, err := h.database.cnx.Query(`
++	var groups_table = "groups"
++	if h.sqlBackend.GetDriverName() == "mysql" {
++		groups_table = "`groups`"
++	}
++	rows, err := h.database.cnx.Query(fmt.Sprintf(`
+ 		SELECT g1.name,g1.gidnumber,ig.includegroupid
+-		FROM groups g1 
++		FROM %s g1
+ 		LEFT JOIN includegroups ig ON g1.gidnumber=ig.parentgroupid 
+-		LEFT JOIN groups g2 ON ig.includegroupid=g2.gidnumber`)
++		LEFT JOIN %s g2 ON ig.includegroupid=g2.gidnumber`, groups_table, groups_table))
+ 	if err != nil {
+ 		return nil, errors.New("Unable to memoize groups list")
+ 	}
+-- 
+2.39.2
+

--- a/patches/0002-Update-the-TRIM_FLAGS-to-use-trimpath.patch
+++ b/patches/0002-Update-the-TRIM_FLAGS-to-use-trimpath.patch
@@ -1,0 +1,30 @@
+From c2ce584e823e6c4d09da588242b9a39b2dff5961 Mon Sep 17 00:00:00 2001
+From: Billy Olsen <billy.olsen@canonical.com>
+Date: Thu, 17 Aug 2023 12:36:49 -0700
+Subject: [PATCH] Update the TRIM_FLAGS to use -trimpath
+
+The current TRIM_FLAGS specify gcflags and asmflags directly in order to
+trim the path of the resulting binaries. This results in an error where
+the plugins cannot be loaded due to the error: "built with a different
+version of package". Per https://github.com/golang/go/issues/51955 in the
+golang repository, this is explicitly not supported. Switching to use the
+go build command's -trimpath flag resolves the issue.
+
+Signed-off-by: Billy Olsen <billy.olsen@canonical.com>
+
+diff --git a/v2/Makefile b/v2/Makefile
+index 0e24e90..27084fc 100644
+--- a/v2/Makefile
++++ b/v2/Makefile
+@@ -18,7 +18,7 @@ GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+ # Build variables
+ BUILD_VARS=-s -w -X main.GitCommit=${GIT_COMMIT} -X main.GitBranch=${GIT_BRANCH} -X main.BuildTime=${BUILD_TIME} -X main.GitClean=${GIT_CLEAN} -X main.LastGitTag=${LAST_GIT_TAG} -X main.GitTagIsCommit=${GIT_IS_TAG_COMMIT}
+ BUILD_FILES=glauth.go
+-TRIM_FLAGS=-gcflags "all=-trimpath=${PWD}" -asmflags "all=-trimpath=${PWD}"
++TRIM_FLAGS=-trimpath
+ 
+ # Targets
+ MAIN_TARGETS=linux/amd64,linux/386,linux/arm64,linux/arm-7,darwin/amd64,darwin/arm64,windows/amd64,windows/386
+-- 
+2.39.2
+

--- a/patches/0003-Update-mysql-schema-for-modern-mysql.patch
+++ b/patches/0003-Update-mysql-schema-for-modern-mysql.patch
@@ -1,0 +1,51 @@
+From 6df28e615c57cf43af9f9183fa8646c941ae7bd3 Mon Sep 17 00:00:00 2001
+From: Billy Olsen <billy.olsen@canonical.com>
+Date: Mon, 14 Aug 2023 16:17:37 -0700
+Subject: [PATCH] Update mysql schema for modern mysql
+
+The groups keyword is reserved in mysql but can still have tables
+using this name if they are quoted with backticks (`). Additionally,
+default values cannot be specified for TEXT types unless wrapped in
+parentheses.
+
+Signed-off-by: Billy Olsen <billy.olsen@canonical.com>
+---
+ mysql.go | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/v2/pkg/plugins/glauth-mysql/mysql.go b/v2/pkg/plugins/glauth-mysql/mysql.go
+index 914889e..db2fe6b 100644
+--- a/v2/pkg/plugins/glauth-mysql/mysql.go
++++ b/v2/pkg/plugins/glauth-mysql/mysql.go
+@@ -44,15 +44,15 @@ CREATE TABLE IF NOT EXISTS users (
+ 	passbcrypt VARCHAR(64) DEFAULT '',
+ 	otpsecret VARCHAR(64) DEFAULT '',
+ 	yubikey VARCHAR(128) DEFAULT '',
+-	sshkeys TEXT DEFAULT '',
+-	custattr TEXT DEFAULT '{}')
++	sshkeys TEXT DEFAULT (''),
++	custattr TEXT DEFAULT ('{}'))
+ `)
+ 	statement.Exec()
+ 	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_user_name on users(name)")
+ 	statement.Exec()
+-	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS groups (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, gidnumber INTEGER NOT NULL)")
++	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS `groups` (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, gidnumber INTEGER NOT NULL)")
+ 	statement.Exec()
+-	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_group_name on groups(name)")
++	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_group_name on `groups`(name)")
+ 	statement.Exec()
+ 	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS includegroups (id INTEGER AUTO_INCREMENT PRIMARY KEY, parentgroupid INTEGER NOT NULL, includegroupid INTEGER NOT NULL)")
+ 	statement.Exec()
+@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS users (
+ // Migrate schema if necessary
+ func (b MysqlBackend) MigrateSchema(db *sql.DB, checker func(*sql.DB, string) bool) {
+ 	if !checker(db, "sshkeys") {
+-		statement, _ := db.Prepare("ALTER TABLE users ADD COLUMN sshkeys TEXT DEFAULT ''")
++		statement, _ := db.Prepare("ALTER TABLE users ADD COLUMN sshkeys TEXT DEFAULT ('')")
+ 		statement.Exec()
+ 	}
+ }
+-- 
+2.39.2
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,14 +49,51 @@ parts:
     source-subdir: v2
     source-type: git
     source: https://github.com/glauth/glauth
-    source-tag: "v2.2.0-RC1"
+    source-branch: master
+    override-pull: |
+      craftctl default
+      
+      # Pull necessary plugins for backend sql databases.
+      need_update=false
+      for plugin in sqlite mysql postgres
+      do
+          if [ ! -d "$CRAFT_PART_SRC_WORK/pkg/plugins/glauth-$plugin" ]
+          then
+              # Pull in the plugins
+              make -C $CRAFT_PART_SRC_WORK pull-plugin U=https://github.com/glauth/glauth-$plugin M=pkg/plugins/glauth-$plugin
+          else
+              echo "Plugin $plugin already exists. submodule update needed."
+              need_update=true
+          fi
+      done
+
+      # Apply local patches
+      for patch in `ls -1 $CRAFT_PROJECT_DIR/patches/*.patch`
+      do
+          echo "Applying patch $patch..."
+          git -C $CRAFT_PART_SRC_WORK apply $patch
+      done
+
     override-build: |
       # Set the version of the snap
       craftctl set version="$(git describe)"
 
       # Build GLAuth
-      make -C $CRAFT_PART_SRC_WORK -j$CRAFT_PARALLEL_BUILD_COUNT fast
-
+      make -C $CRAFT_PART_SRC_WORK -j$CRAFT_PARALLEL_BUILD_COUNT TRIM_FLAGS="-trimpath" fast
+      
+      # Build plugins
+      available_plugins=$(ls -1 $CRAFT_PART_SRC_WORK/pkg/plugins | grep "glauth-" | cut -f2 -d'-')
+      for plugin in $available_plugins
+      do
+          echo "Building plugin $plugin"
+          make -C $CRAFT_PART_SRC_WORK plugin_$plugin
+      done
+      
       # Grab built binary
       mkdir -p $CRAFT_PART_INSTALL/bin
-      cp -r $CRAFT_PART_SRC_WORK/bin/*/glauth $CRAFT_PART_INSTALL/bin/
+      cp $CRAFT_PART_SRC_WORK/bin/linux$CRAFT_TARGET_ARCH/glauth $CRAFT_PART_INSTALL/bin/
+      
+      # Copy the plugin .so files to the lib directory
+      mkdir -p $CRAFT_PART_INSTALL/lib/glauth
+      cp $CRAFT_PART_SRC_WORK/bin/linux$CRAFT_TARGET_ARCH/*.so $CRAFT_PART_INSTALL/lib/glauth/
+


### PR DESCRIPTION
Add support to the snap for various databases. Plugins in GLAuth are implemented as plugins and live in separate repositories. Pull these repositories in and build the plugins.

This also adds 3 patches to the upstream glauth source code which have been forwarded in one form or another. These patches do the following:

1. Special case the mysql backend inside the basesqlhandler.go to escape the groups table name.
2. Update the TRIM flags on the build process in order to build compatible plugins
3. Update the mysql plugin to escape the groups table and some of the default values to be compliant with mysql.
